### PR TITLE
Specific OCF command support for Samsung Soundbar HW-Q900A

### DIFF
--- a/lib/ocf/ocfDeviceFactory.js
+++ b/lib/ocf/ocfDeviceFactory.js
@@ -1,0 +1,58 @@
+const ocfDevices = {
+    "Samsung Electronics~VD-NetworkAudio-002S": {
+        getOcfCommands: function() {
+            return {
+                nightmode: {
+                    href: "/sec/networkaudio/advancedaudio",
+                    type: "boolean",
+                    translate: function(value) {
+                        return {
+                            "x.com.samsung.networkaudio.nightmode": value ? 1 : 0
+                        };
+                    }
+                }
+            };
+        }
+    }
+};
+
+module.exports = class OcfDeviceFactory {
+    constructor() {
+    }
+
+    getOcfDevice(deviceManufacturerCode, presentationId) {
+        return ocfDevices[`${deviceManufacturerCode}~${presentationId}`];
+    }
+
+    getOcfCommandData(deviceManufacturerCode, presentationId, deviceId, commandName, value) {
+        const ocfDevice = this.getOcfDevice(deviceManufacturerCode, presentationId);
+        if (!ocfDevice) {
+            return null;
+        }
+
+        const commands = ocfDevice.getOcfCommands();
+        if (!commands) {
+            return null;
+        }
+
+        const command = commands[commandName];
+        if (!command) {
+            return null;
+        }
+
+        const attributes = command.translate(value);
+        return {
+            "commands":[
+                {
+                    "component":"main",
+                    "capability":"ocf",
+                    "command":"postOcfCommand",
+                    "arguments":[
+                        `/oic/route/${deviceId}${command.href}`,
+                        attributes
+                    ]
+                }
+            ]
+        };
+    }
+};

--- a/lib/ocf/ocfDeviceFactory.js
+++ b/lib/ocf/ocfDeviceFactory.js
@@ -10,6 +10,91 @@ const ocfDevices = {
                             "x.com.samsung.networkaudio.nightmode": value ? 1 : 0
                         };
                     }
+                },
+                voiceamplifier: {
+                    href: "/sec/networkaudio/advancedaudio",
+                    type: "boolean",
+                    translate: function(value) {
+                        return {
+                            "x.com.samsung.networkaudio.voiceamplifier": value ? 1 : 0
+                        };
+                    }
+                },
+                bassboost: {
+                    href: "/sec/networkaudio/advancedaudio",
+                    type: "boolean",
+                    translate: function(value) {
+                        return {
+                            "x.com.samsung.networkaudio.bassboost": value ? 1 : 0
+                        };
+                    }
+                },
+                soundmode: {
+                    href: "/sec/networkaudio/soundmode",
+                    iobroker: {
+                        type: "number",
+                        min: 0,
+                        max: 3,
+                        states: "0:Standard;1:Surround;2:Game;3:Adaptive Sound",
+                        convert: function(value) {
+                            switch (value) {
+                                case 1:
+                                    return "surround";
+                                case 2:
+                                    return "game";
+                                case 3:
+                                    return "adaptive sound";
+                                default:
+                                    return "standard";
+                            }
+                        }
+                    },
+                    translate: function(value) {
+                        return {
+                            "x.com.samsung.networkaudio.soundmode": value
+                        };
+                    }
+                },
+                soundfrom: {
+                    href: "/sec/networkaudio/soundFrom",
+                    iobroker: {
+                        type: "number",
+                        min: 0,
+                        max: 1,
+                        states: "0:Digital;1:Wifi",
+                        convert: function(value) {
+                            switch (value) {
+                                case 0:
+                                    return "digital";
+                                case 1:
+                                    return "wifi";
+                            }
+                        }
+                    },
+                    translate: function(value) {
+                        let parameter = {};
+                        let sbMode = 0;
+                        let deviceName = "";
+
+                        switch (value) {
+                            case "digital":
+                                parameter = {"status":1,"name":"External Device","groupName":"","duid":"","sbMode":1,"mac":"","di":"","deviceType":4,"ip":"","connectionType":"D-IN/TV ARC"};
+                                sbMode = 1;
+                                deviceName = "External Device";
+                                break;
+                            case "wifi":
+                                parameter = {"status":1,"name":"Samsung QN95AA 75 TV","groupName":"[AV] Samsung Soundbar Q900A","duid":"","sbMode":9,"mac":"","di":"","deviceType":1,"ip":"","connectionType":"WIFI"};
+                                sbMode = 9;
+                                deviceName = "Samsung QN95AA 75 TV";
+                                break;
+                        }
+
+                        return {
+                            "x.com.samsung.networkaudio.soundFrom": parameter,
+                            "x.com.samsung.networkaudio.sbMode": sbMode,
+                            "x.com.samsung.networkaudio.name": deviceName
+                        };
+                    }
                 }
             };
         }
@@ -40,7 +125,12 @@ module.exports = class OcfDeviceFactory {
             return null;
         }
 
-        const attributes = command.translate(value);
+        let converted = value;
+        if (command.iobroker) {
+            converted = command.iobroker.convert(value);
+        }
+
+        const attributes = command.translate(converted);
         return {
             "commands":[
                 {

--- a/lib/ocf/readme.md
+++ b/lib/ocf/readme.md
@@ -1,0 +1,148 @@
+OCF basically translates into "Open Connectivity Foundation". So, any device, Smartthings is exposing with an "sendOcfCommand" capability, should be enabled to recieve a specific command and parameters.
+Having bought a new Soundbar as well as a new TV recently, I realized soon that Samsung (and its public SDK/API) not to on a par with their Smartthings (Android) App. Which was kind of a problem for me, just because, I wanted to continue to use my Logitech Harmony to talk to something that enables me to control the Nightmode as well as the Voice Amplifier option from that remote.
+Also, I wanted to be able to specifically chose the input the Soundbar is listening for, so I was looking for a solution.
+
+After some research and looking into the following
+- https://sites.google.com/view/samsungwirelessaudiomultiroom/
+- https://github.com/wdrc/WAM_API_DOC
+- https://github.com/DaveGut/DEPRECATED-SmartThings_Samsung-WiFi-Audio-Unofficial/blob/master/0%20-%20DeviceHandler/Samsung%20WiFi%20Audio%20DH-V4.groovy
+- https://github.com/SmartThingsCommunity/smartthings-cli
+- https://openconnectivityfoundation.github.io/development-support/DeviceSpy/
+
+I just found out that there has to be a better way to understand what Smartthings is doing.
+So, the new plan was to have a look into their APK & Code, so I can reverse engineer. Downloading the APK from somewhere and using a Java decompiler (https://github.com/skylot/jadx) I run into a wall just one more time. Just because the main APK is nothing but the main implementation of something that can be used to host custom plugins for the specific devices found in your setup. So I had to somehow get the plugin APK to decompile... Then I realized that I cannot access the data folder on my device anymore just because Google locked down things... :) I hear you say: root? Yeah, thats exactly what I have done next. Instead of breaking my real Pixel 5, I have installed Android Studio, installed a fresh SDK (with a link to Google PlayStore) and started to root this using
+- https://forum.xda-developers.com/t/script-rootavd-root-your-android-studio-virtual-device-emulator-with-magisk-android-12-linux-darwin-macos-win-google-play-store-apis.4218123/
+
+to get access to the Android data folder within the AVD. Thankfully, that has been quite straight forward, so after root, I just installed a File Explorer as well as SmartThings, logged in (so to have Smartthing download its plugins) and then grabbed LifeStyleAudio Plugin.apk from the virtual Android device.
+
+Actually, just as a side note, I have not been able to talk to my Soundbar nor my TV from within the virtual device, but I have now had the codes to start understanding things. Looking into the resource file they have just had to compile into their APK, I was able to quite soon find the corresponding lines of code responsible to control Nightmode as well as Voice Amplifier but, as I am totally off when it comes to Android development, I wasn't able to actually trace down the individual command they are sending. BUT! I just found out that they are using the Android Log a LOT! :)
+
+Thanks to adb logcat (and enabling USB debugging on my device), I was now able to at least capture some of the objects they are sending out somewhere... Anything else, by looking into their Smartthings API description, was just trail and error until I have found the correct command to be send. Your command structure into an OCF device is something like the following.
+
+Control Nightmode for HW-Q900A
+```
+POST https://api.smartthings.com/devices/{deviceId}}/commands
+Auth: Bearer Token
+Body:
+{
+    "commands":[
+        {
+            "component":"main",
+            "capability":"ocf",
+            "command":"postOcfCommand",
+            "arguments":[
+                "/oic/route/{deviceId}/sec/networkaudio/advancedaudio",
+                {
+                    "x.com.samsung.networkaudio.nightmode": 0
+                }
+            ]
+        }
+    ]
+}
+
+```
+
+Control Voice amplifier for HW-Q900A
+```
+POST https://api.smartthings.com/devices/{deviceId}}/commands
+Auth: Bearer Token
+Body:
+{
+    "commands":[
+        {
+            "component":"main",
+            "capability":"ocf",
+            "command":"postOcfCommand",
+            "arguments":[
+                "/oic/route/{deviceId}/sec/networkaudio/advancedaudio",
+                {
+                    "x.com.samsung.networkaudio.voiceamplifier": 0
+                }
+            ]
+        }
+    ]
+}
+
+```
+
+Control bass boost for HW-Q900A
+```
+POST https://api.smartthings.com/devices/{deviceId}}/commands
+Auth: Bearer Token
+Body:
+{
+    "commands":[
+        {
+            "component":"main",
+            "capability":"ocf",
+            "command":"postOcfCommand",
+            "arguments":[
+                "/oic/route/{deviceId}/sec/networkaudio/advancedaudio",
+                {
+                    "x.com.samsung.networkaudio.bassboost": 0
+                }
+            ]
+        }
+    ]
+}
+
+```
+
+Control sound mode for HW-Q900A
+```
+POST https://api.smartthings.com/devices/{deviceId}}/commands
+Auth: Bearer Token
+Body:
+{
+    "commands":[
+        {
+            "component":"main",
+            "capability":"ocf",
+            "command":"postOcfCommand",
+            "arguments":[
+                "/oic/route/{deviceId}/sec/networkaudio/soundmode",
+                {
+                    "x.com.samsung.networkaudio.soundmode": "adaptive sound"
+                }
+            ]
+        }
+    ]
+}
+
+```
+
+Control sound source for HW-Q900A
+```
+POST https://api.smartthings.com/devices/{deviceId}}/commands
+Auth: Bearer Token
+Body:
+{
+    "commands":[
+        {
+            "component":"main",
+            "capability":"ocf",
+            "command":"postOcfCommand",
+            "arguments":[
+                "/oic/route/{deviceId}/sec/networkaudio/soundFrom",
+                {
+                    "x.com.samsung.networkaudio.soundFrom": {
+                        "status":1,
+                        "name":"External Device",
+                        "groupName":"",
+                        "duid":"",
+                        "sbMode":1,
+                        "mac":"",
+                        "di":"",
+                        "deviceType":4,
+                        "ip":"",
+                        "connectionType":"D-IN/TV ARC"
+                    },
+                    "x.com.samsung.networkaudio.sbMode": 1,
+                    "x.com.samsung.networkaudio.name": "External Device"
+                }
+            ]
+        }
+    ]
+}
+
+```

--- a/main.js
+++ b/main.js
@@ -129,12 +129,16 @@ class Smartthings extends utils.Adapter {
                                                 const ocfDeviceCommands = ocfDevice.getOcfCommands();
                                                 for (const ocfDeviceCommandName in ocfDeviceCommands) {
                                                     const ocfDeviceCommand = ocfDeviceCommands[ocfDeviceCommandName];
-                                                    this.setObjectNotExists(device.deviceId + ".capabilities." + letsubIdName + "." + ocfDeviceCommandName, {
+
+                                                    const objectRaw = {
                                                         type: "state",
                                                         common: {
                                                             name: "",
-                                                            type: ocfDeviceCommand.type,
-                                                            role: ocfDeviceCommand.type,
+                                                            type: ocfDeviceCommand.iobroker ? ocfDeviceCommand.iobroker.type : ocfDeviceCommand.type,
+                                                            role: ocfDeviceCommand.iobroker ? ocfDeviceCommand.iobroker.type : ocfDeviceCommand.type,
+                                                            min: ocfDeviceCommand.iobroker && ocfDeviceCommand.iobroker.min ? ocfDeviceCommand.iobroker.min : 0,
+                                                            max: ocfDeviceCommand.iobroker && ocfDeviceCommand.iobroker.max ? ocfDeviceCommand.iobroker.max : 0,
+                                                            states: ocfDeviceCommand.iobroker && ocfDeviceCommand.iobroker.states ? ocfDeviceCommand.iobroker.states : null,
                                                             write: true,
                                                             read: true
                                                         },
@@ -145,7 +149,8 @@ class Smartthings extends utils.Adapter {
                                                             deviceId: device.deviceId,
                                                             commandName: ocfDeviceCommandName
                                                         }
-                                                    });
+                                                    };
+                                                    this.setObjectNotExists(device.deviceId + ".capabilities." + letsubIdName + "." + ocfDeviceCommandName, objectRaw);
                                                 }
                                                 commandCreated = true;
                                             }

--- a/main.js
+++ b/main.js
@@ -9,6 +9,8 @@
 const utils = require("@iobroker/adapter-core");
 const axios = require("axios");
 const Json2iob = require("./lib/json2iob");
+const OcfDeviceFactory = require('./lib/ocf/ocfDeviceFactory');
+
 class Smartthings extends utils.Adapter {
     /**
      * @param {Partial<utils.AdapterOptions>} [options={}]
@@ -39,6 +41,7 @@ class Smartthings extends utils.Adapter {
         this.json2iob = new Json2iob(this);
         this.deviceArray = [];
         this.session = {};
+        this.ocfDeviceFactory = new OcfDeviceFactory();
         this.subscribeStates("*");
 
         if (this.config.token) {
@@ -118,24 +121,56 @@ class Smartthings extends utils.Adapter {
                                             read: true,
                                         };
                                         const letsubIdName = idName + "-" + element;
-                                        if (res.data.commands[element].arguments[0]) {
-                                            common.type = res.data.commands[element].arguments[0].schema.type;
-                                            if (common.type === "integer") {
-                                                common.type = "number";
-                                            }
-                                            common.role = "state";
-                                            if (res.data.commands[element].arguments[0].schema.enum) {
-                                                common.states = {};
-                                                res.data.commands[element].arguments[0].schema.enum.forEach((enumElement) => {
-                                                    common.states[enumElement] = enumElement;
-                                                });
+
+                                        let commandCreated = false;
+                                        if (idName === "ocf" && element === "postOcfCommand") {
+                                            const ocfDevice = this.ocfDeviceFactory.getOcfDevice(device.deviceManufacturerCode, device.presentationId);
+                                            if (ocfDevice) {
+                                                const ocfDeviceCommands = ocfDevice.getOcfCommands();
+                                                for (const ocfDeviceCommandName in ocfDeviceCommands) {
+                                                    const ocfDeviceCommand = ocfDeviceCommands[ocfDeviceCommandName];
+                                                    this.setObjectNotExists(device.deviceId + ".capabilities." + letsubIdName + "." + ocfDeviceCommandName, {
+                                                        type: "state",
+                                                        common: {
+                                                            name: "",
+                                                            type: ocfDeviceCommand.type,
+                                                            role: ocfDeviceCommand.type,
+                                                            write: true,
+                                                            read: true
+                                                        },
+                                                        native: {
+                                                            type: "OcfCommand",
+                                                            deviceManufacturerCode: device.deviceManufacturerCode,
+                                                            presentationId: device.presentationId,
+                                                            deviceId: device.deviceId,
+                                                            commandName: ocfDeviceCommandName
+                                                        }
+                                                    });
+                                                }
+                                                commandCreated = true;
                                             }
                                         }
-                                        this.setObjectNotExists(device.deviceId + ".capabilities." + letsubIdName, {
-                                            type: "state",
-                                            common: common,
-                                            native: {},
-                                        });
+
+                                        if (!commandCreated) {
+                                            if (res.data.commands[element].arguments[0]) {
+                                                common.type = res.data.commands[element].arguments[0].schema.type;
+                                                if (common.type === "integer") {
+                                                    common.type = "number";
+                                                }
+                                                common.role = "state";
+                                                if (res.data.commands[element].arguments[0].schema.enum) {
+                                                    common.states = {};
+                                                    res.data.commands[element].arguments[0].schema.enum.forEach((enumElement) => {
+                                                        common.states[enumElement] = enumElement;
+                                                    });
+                                                }
+                                            }
+                                            this.setObjectNotExists(device.deviceId + ".capabilities." + letsubIdName, {
+                                                type: "state",
+                                                common: common,
+                                                native: {},
+                                            });
+                                        }
                                     });
                                 })
                                 .catch((error) => {
@@ -245,10 +280,20 @@ class Smartthings extends utils.Adapter {
                 let capadId = idArray.join(".");
                 const commandId = capadId.split("-")[1];
                 capadId = capadId.split("-")[0];
-                const data = { commands: [{ capability: capadId, command: commandId }] };
+
+                let data = { commands: [{ capability: capadId, command: commandId }] };
                 if (typeof state.val !== "boolean") {
                     data.commands[0].arguments = [state.val];
                 }
+
+                if (capadId === "ocf" && commandId.startsWith("postOcfCommand")) {
+                    const commandObject = await this.getForeignObjectAsync(id).then(result => result);
+                    const candidate = this.ocfDeviceFactory.getOcfCommandData(commandObject.native.deviceManufacturerCode, commandObject.native.presentationId, commandObject.native.deviceId, commandObject.native.commandName, state.val);
+                    if (candidate !== null) {
+                        data = candidate;
+                    }
+                }
+
                 this.log.info(JSON.stringify(data));
                 await this.requestClient({
                     method: "post",


### PR DESCRIPTION
This enables you to, from within iobroker, directly have the Adapter understand and emit specific OCF command for known devices. First known device is Samsung HW-Q900A (which should be quite similar to HW-Q950A which I would expect to be supported directly as well).